### PR TITLE
Fix for tralining comma error in Slider.js file

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -316,7 +316,7 @@ export default class Slider extends PureComponent {
       style,
       trackStyle,
       thumbStyle,
-      ...otherProps,
+      ...otherProps
     } = props;
 
     return otherProps;


### PR DESCRIPTION
Fix for error: 'A trailing comma is not permitted after the rest element' in Slider.js file.